### PR TITLE
Fix version reference in example snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Following are the prerequisites for this GitHub Action:
 
 ```
 - name: JMeter Test
-  uses: QAInsights/PerfAction@3.1
+  uses: QAInsights/PerfAction@v3.1
   with:
     test-plan-path: ./TestPlans/S01_SimpleExample/S01_SimpleExample.jmx
     args: ""
@@ -45,7 +45,7 @@ Following are the prerequisites for this GitHub Action:
 
 ```
 - name: JMeter Test
-  uses: QAInsights/PerfAction@3.1
+  uses: QAInsights/PerfAction@v3.1
   with:
     test-plan-path: ./TestPlans/S01_SimpleExample/S01_SimpleExample.jmx
     args: "-H my.proxy.server -P 8000"


### PR DESCRIPTION
Incorrect reference of QAInsights/PerfAction@3.1 since it is missing the "v".