### PR TITLE
Add option to specify a different result file.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,10 @@ jobs:
         with:
           test-plan-path: ./TestPlans/S01_SimpleExample/S01_SimpleExample.jmx
           args: ""
+          results-file: result.csv
           
       - name: Upload Results
         uses: actions/upload-artifact@v2
         with:
           name: jmeter-results
-          path: result.jtl
+          path: result.csv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,9 @@ jobs:
         with:
           test-plan-path: ./TestPlans/S01_SimpleExample/S01_SimpleExample.jmx
           args: ""
-          results-file: result.csv
           
       - name: Upload Results
         uses: actions/upload-artifact@v2
         with:
           name: jmeter-results
-          path: result.csv
+          path: result.jtl

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Following are the prerequisites for this GitHub Action:
 
 ## Download JMeter Test Results
 
-By default, this GitHub Action will log the performance statistics under `result.jtl` if no other file is specified. After the execution, it will be uploaded to the GitHub artifacts.
+By default, this GitHub Action will log the performance statistics under `result.jtl`. After the execution, it will be uploaded to the GitHub artifacts.
 
 To download the JMeter results, go to your `Actions` and then click on the executed workflow, then click on `jmeter-results` link which will download the zip file.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Following are the prerequisites for this GitHub Action:
 * `args`
   * Optional
   * Additional arguments you can pass it to your test plan execution
-* `test-results``
+* `test-results`
   * Optional
   * If you want your result to have a different extension than jtl e.g., .csv
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Following are the prerequisites for this GitHub Action:
 * `args`
   * Optional
   * Additional arguments you can pass it to your test plan execution
+* `test-results``
+  * Optional
+  * If you want your result to have a different extension than jtl e.g., .csv
 
 ## Usage
 
@@ -41,7 +44,7 @@ Following are the prerequisites for this GitHub Action:
     path: result.jtl
 ```
 
-### Example #2 with arguments
+### Example #2 with arguments and a custom results file
 
 ```
 - name: JMeter Test
@@ -49,17 +52,18 @@ Following are the prerequisites for this GitHub Action:
   with:
     test-plan-path: ./TestPlans/S01_SimpleExample/S01_SimpleExample.jmx
     args: "-H my.proxy.server -P 8000"
+    test-results: result.csv
     
 - name: Upload Results
   uses: actions/upload-artifact@v2
   with:
     name: jmeter-results
-    path: result.jtl
+    path: result.csv
 ```
 
 ## Download JMeter Test Results
 
-By default, this GitHub Action will log the performance statistics under `result.jtl`. After the execution, it will be uploaded to the GitHub artifacts.
+By default, this GitHub Action will log the performance statistics under `result.jtl` if no other file is specified. After the execution, it will be uploaded to the GitHub artifacts.
 
 To download the JMeter results, go to your `Actions` and then click on the executed workflow, then click on `jmeter-results` link which will download the zip file.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Following are the prerequisites for this GitHub Action:
   * Additional arguments you can pass it to your test plan execution
 * `test-results`
   * Optional
-  * If you want your result to have a different extension than jtl e.g., .csv
+  * If you want your result to have a different extension than jtl such as .csv
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: jmeter test plan to execute
   results-file:
     required: false
-    description: Where to store the results e.g., result.jtl
+    description: Where to store the results e.g., results.csv
   args:
     required: false
     description: Optional arguments. For more details https://jmeter.apache.org/usermanual/get-started.html#non_gui

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ runs:
   - "-t"
   - "${{ inputs.test-plan-path }}"
   - "-l"
-  - '${{ inputs.results-file }}'
+  - "${{ inputs.results-file }}"
   - "${{ inputs.args }}"

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ inputs:
   results-file:
     required: false
     description: Where to store the results e.g., results.csv
+    default: result.jtl
   args:
     required: false
     description: Optional arguments. For more details https://jmeter.apache.org/usermanual/get-started.html#non_gui

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: jmeter test plan to execute
   results-file:
     required: false
-    description: Where to store the results e.g., results.csv
+    description: Where to store the results e.g., result.csv
     default: result.jtl
   args:
     required: false

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   test-plan-path:
     required: true
     description: jmeter test plan to execute
+  results-file:
+    required: false
+    description: Where to store the results e.g., result.jtl
   args:
     required: false
     description: Optional arguments. For more details https://jmeter.apache.org/usermanual/get-started.html#non_gui
@@ -23,5 +26,5 @@ runs:
   - "-t"
   - "${{ inputs.test-plan-path }}"
   - "-l"
-  - "result.jtl"
+  - '${{ inputs.results-file }}'
   - "${{ inputs.args }}"


### PR DESCRIPTION
Added the option to specify a different result file other than `result.jtl`. I've [verified](https://github.com/TimJonsson/Jmeter-tests/actions/runs/4413515533) that a .csv file works and also that not using the input `test-results` still [saved](https://github.com/TimJonsson/Jmeter-tests/actions/runs/4413498164) it into `result.jtl` 

I also verified the `action.yml` in my own [fork](https://github.com/TimJonsson/PerfAction/actions/runs/4413141821)