### PR TITLE
Add "if-no-files-found: error" to examples and main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,11 @@ jobs:
       with:
         name: jmeter-results
         path: result.jtl
+        if-no-files-found: error
 
     - name: Upload HTML Reports
       uses: actions/upload-artifact@v3
       with:
         name: jmeter-reports
         path: reports
+        if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Following are the prerequisites for this GitHub Action:
   with:
     name: jmeter-results
     path: result.jtl
+    if-no-files-found: error
 ```
 
 ### Example #2 with arguments
@@ -59,6 +60,7 @@ Following are the prerequisites for this GitHub Action:
   with:
     name: jmeter-results
     path: result.jtl
+    if-no-files-found: error
 ```
 ### Example #3 with arguments to Generate HTML Reports
 
@@ -79,12 +81,14 @@ Please make sure that you create a directory where you want to generate HTML rep
   with:
     name: jmeter-results
     path: result.jtl
+    if-no-files-found: error
 
 - name: Upload HTML Reports
   uses: actions/upload-artifact@v3
   with:
     name: jmeter-html-reports
     path: reports
+    if-no-files-found: error
 ```
 
 ## 📥 Download JMeter Test Results


### PR DESCRIPTION
If you accidentally enter a wrong name for your test file, the action will not fail. In my opinion, the action should not be successful when you fail to specify the correct test name. The reason for this is that upload-artifact uses` if-no-files-found: warn` as the default level. 

Adding `if-no-files-found: error ` to the example files will save people new to GitHub Actions some confusion.

## Example without specifying `if-no-files-found` :

![image](https://github.com/QAInsights/PerfAction/assets/98179508/2523bcf1-8950-4ba1-a3b6-c5cb12adced8)

## Example when using `if-no-files-found: error`
![image](https://github.com/QAInsights/PerfAction/assets/98179508/e16eee5a-c95a-4d23-a8d6-20153fbba598)
