### PR TITLE
chore: bump JMeter version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL Author="NaveenKumar Namachivayam"
 LABEL Website="https://qainsights.com"
 LABEL Description="Apache JMeter Dockerfile for GitHub Actions with JMeter Plugins"
 
-ENV JMETER_VERSION "5.6.2"
+ENV JMETER_VERSION "5.6.3"
 ENV JMETER_HOME "/opt/apache/apache-jmeter-${JMETER_VERSION}"
 ENV JMETER_BIN "${JMETER_HOME}/bin"
 ENV PATH "$PATH:$JMETER_BIN"


### PR DESCRIPTION
Bumped the JMeter version from 5.6.2 to 5.6.3 as it includes several bug fixes